### PR TITLE
fix: 修复typescript_type.ftl模板因comment出现null而导致"生成错误,服务器错误"的问题

### DIFF
--- a/src/main/resources/templates/typescript_type.ftl
+++ b/src/main/resources/templates/typescript_type.ftl
@@ -5,7 +5,9 @@
 interface ${className} {
 <#-- 循环生成字段 ---------->
 <#list fieldList as field>
-  // ${field.comment}
+  <#if field.comment??>
+    // ${field.comment}
+  </#if>
   ${field.fieldName}: ${field.typescriptType};
 </#list>
 }


### PR DESCRIPTION
![图片](https://user-images.githubusercontent.com/53216212/235718519-5b678289-0b09-48ac-a591-eec671264660.png)
